### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -38,3 +40,6 @@ jobs:
 
       - name: Run tests
         run: spago -x test.dhall test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/src/Data/Float32.purs
+++ b/src/Data/Float32.purs
@@ -1,12 +1,26 @@
 module Data.Float32
-  ( Float32, fromNumber, fromNumber', toNumber
+  ( Float32
+  , fromNumber
+  , fromNumber'
+  , toNumber
   ) where
 
 import Prelude
-  ( class Eq, class Ord, class Show, class Semiring, class Ring, class Bounded, class EuclideanRing
-  , class CommutativeRing, class DivisionRing
-  , top, bottom, (==), (||))
-import Data.Maybe (Maybe (..))
+  ( class Eq
+  , class Ord
+  , class Show
+  , class Semiring
+  , class Ring
+  , class Bounded
+  , class EuclideanRing
+  , class CommutativeRing
+  , class DivisionRing
+  , top
+  , bottom
+  , (==)
+  , (||)
+  )
+import Data.Maybe (Maybe(..))
 
 -- | [32-bit single-precision floating-point](https://en.wikipedia.org/wiki/Single-precision_floating-point_format)
 -- | number.
@@ -24,17 +38,17 @@ instance boundedFloat32 :: Bounded Float32 where
   top = float32Top
   bottom = float32Bottom
 
-
 foreign import float32Top :: Float32
 foreign import float32Bottom :: Float32
-
 
 -- | Uses `Math.fround()` to convert to a `Float32`.
 -- | Returns `Nothing` when outside the range.
 fromNumber :: Number -> Maybe Float32
 fromNumber x =
-  let r = fromNumberImpl x
-  in  if r == top || r == bottom then Nothing else Just (Float32 r)
+  let
+    r = fromNumberImpl x
+  in
+    if r == top || r == bottom then Nothing else Just (Float32 r)
 
 -- | Uses `Math.fround()` to convert to a `Float32`.
 -- | Returns *0.0* when outside the range.
@@ -42,7 +56,6 @@ fromNumber' :: Number -> Float32
 fromNumber' x = case fromNumber x of
   Nothing -> Float32 0.0
   Just y -> y
-
 
 foreign import fromNumberImpl :: Number -> Number
 

--- a/src/Data/Float32/Gen.purs
+++ b/src/Data/Float32/Gen.purs
@@ -4,6 +4,5 @@ import Prelude ((<$>))
 import Data.Float32 (Float32, fromNumber', toNumber)
 import Control.Monad.Gen.Class (class MonadGen, chooseFloat)
 
-
 chooseFloat32 :: forall m. MonadGen m => Float32 -> Float32 -> m Float32
 chooseFloat32 a b = fromNumber' <$> chooseFloat (toNumber a) (toNumber b)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,6 +10,7 @@ import Test.QuickCheck.Laws.Data (checkBounded, checkCommutativeRing, checkEq, c
 import Type.Proxy (Proxy(..))
 
 newtype Float32' = Float32' Float32
+
 derive newtype instance eqFloat32' :: Eq Float32'
 derive newtype instance ordFloat32' :: Ord Float32'
 derive newtype instance boundedFloat32' :: Bounded Float32'
@@ -21,26 +22,17 @@ derive newtype instance euclideanRingFloat32' :: EuclideanRing Float32'
 instance arbitraryFloat32' :: Arbitrary Float32' where
   arbitrary = Float32' <$> chooseFloat32 bottom top
 
-
 main :: Effect Unit
 main = do
-  let p :: Proxy Float32'
-      p = Proxy
+  let
+    p :: Proxy Float32'
+    p = Proxy
   checkBounded p
   checkEq p
   checkOrd p
   checkSemiring p
   checkRing p
   checkCommutativeRing p
-  -- checkDivisionRing p -- isn't a division ring because 32bit float isn't perfectly precise
-  -- checkEuclideanRing p -- likewise for euclidean ring
-
-
-
-
-
-
-
-
-
+-- checkDivisionRing p -- isn't a division ring because 32bit float isn't perfectly precise
+-- checkEuclideanRing p -- likewise for euclidean ring
 


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
